### PR TITLE
add `-bios none' to silence qemu

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -170,7 +170,7 @@ endif
 
 QEMUEXTRA = -drive file=fs1.img,if=none,format=raw,id=x1 -device virtio-blk-device,drive=x1,bus=virtio-mmio-bus.1
 
-QEMUOPTS = -machine virt -kernel $K/kernel -m 3G -smp $(CPUS) -nographic
+QEMUOPTS = -machine virt -bios none -kernel $K/kernel -m 3G -smp $(CPUS) -nographic
 QEMUOPTS += -drive file=fs.img,if=none,format=raw,id=x0 -device virtio-blk-device,drive=x0,bus=virtio-mmio-bus.0
 
 qemu: $K/kernel fs.img


### PR DESCRIPTION
QEMU 4.1+ emits warnings if -bios is not given, as newer versions
will load the OpenSBI firmware in this case.  Pass `-bios none' to
avoid this issue.