### PR TITLE
Fix an off-by-one in size() function

### DIFF
--- a/kernel/buddy.c
+++ b/kernel/buddy.c
@@ -156,7 +156,7 @@ bd_malloc(uint64 nbytes)
 // Find the size of the block that p points to.
 int
 size(char *p) {
-  for (int k = 0; k < nsizes; k++) {
+  for (int k = 0; k < MAXSIZE; k++) {
     if(bit_isset(bd_sizes[k+1].split, blk_index(k+1, p))) {
       return k;
     }


### PR DESCRIPTION
bd_sizes has nsizes elements.  Thus if k == nsizes-1, we might read
past the buffer.